### PR TITLE
fix: 修正 Llama3.2 实验8 infer-11b.py 代码

### DIFF
--- a/实验答案/实验八/llama3.2/infer-11b.py
+++ b/实验答案/实验八/llama3.2/infer-11b.py
@@ -3,44 +3,26 @@ import torch
 import torch_mlu
 from PIL import Image
 from transformers import MllamaForConditionalGeneration, AutoProcessor
-
 model_id = "/workspace/model/favorite/large-scale-models/model-v1/Llama-3.2-11B-Vision-Instruct/"
-
-# ✅ 加载条件生成模型，指定模型路径、数据类型和MLU设备
-model = MllamaForConditionalGeneration.from_pretrained(
-    model_id,
-    torch_dtype=torch.float16,
-).to("mlu")
-
-# ✅ 从预训练模型加载处理器
+#TODO: 加载条件生成模型，指定模型路径、数据类型和MLU设备
+model = MllamaForConditionalGeneration.from_pretrained(model_id, torch_dtype=torch.float16, device_map="auto")
+#TODO:  从预训练模型加载处理器，使用指定的模型路径
 processor = AutoProcessor.from_pretrained(model_id)
-
-# ✅ 打开本地图像文件
-image = Image.open("text2img.jpg")  # <-- 请替换为实际图像路径
-
-# ✅ 定义用户消息，包含图片和文本
+#TODO: 打开本地的图像文件
+image = Image.open("text2img.jpg")
+#TODO: 定义用户消息
 messages = [
-    {"role": "user", "content": [
-        {"type": "image", "image": image},
-        {"type": "text", "text": "If I had to write a haiku for this one, it would be: "}
-    ]}
+ {"role": "user", "content": [
+ {"type": "image"},
+ {"type": "text", "text": "If I had to write a haiku for this one, it would be: "}
+ ]}
 ]
-
-# ✅ 应用聊天模板（如支持 ChatML 格式）
-input_text = processor.apply_chat_template(messages, tokenize=False)
-
-# ✅ 处理图像和文本输入
-inputs = processor(
-    text=input_text,
-    images=image,
-    return_tensors="pt"
-).to("mlu")
-
-# ✅ 使用模型生成文本
-output = model.generate(**inputs, max_new_tokens=64)
-
-# ✅ 解码输出
-generated_text = processor.tokenizer.decode(output[0], skip_special_tokens=True)
-print(generated_text)
-
+#TODO: 应用聊天模板，将消息转化为适合模型的输入格式
+input_text = processor.apply_chat_template(messages, add_generation_prompt=True)
+#TODO: 处理图像和文本输入，将其转换为模型可以接受的格式，并将其转移到 MLU 设备上
+inputs = processor(image, input_text, return_tensors="pt").to(model.device)
+# 使用模型生成文本，新 token 数量可做限制
+output = model.generate(**inputs, max_new_tokens=30)
+#TODO:解码模型生成的输出并打印结果，以获取可读的文本形式
+print(processor.decode(output[0]))
 print("Llama3.2 multimodalchat PASS!")


### PR DESCRIPTION
### 修改内容
- 修正实验8 Llama3.2 的 infer-11b.py 代码
在最近的希冀平台中，需限制模型生成token，否则将报错Runtime error。限制token后，将运行成功，并得分100分。
<img width="1996" height="1294" alt="截屏2026-01-18 00 08 46" src="https://github.com/user-attachments/assets/87e31a7f-a561-4745-a217-cb92bd97508e" />
<img width="1944" height="1088" alt="截屏2026-01-17 21 39 34" src="https://github.com/user-attachments/assets/82adf07b-f6e1-4858-b30d-93b112cbdc1b" />
